### PR TITLE
bump to 0.2.1

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,18 +29,18 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-pandoc@v1
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: rcmdcheck
 
-      - uses: r-lib/actions/check-r-package@v1
+      - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -15,15 +15,15 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: pkgdown
           needs: website

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: workboots
 Title: Generate Bootstrap Prediction Intervals from a 'tidymodels' Workflow
-Version: 0.2.0.9000
+Version: 0.2.1
 Authors@R:
     person(given = "Mark",
            family = "Rieke",
@@ -28,12 +28,12 @@ Imports:
     stats,
     tibble,
     tidyr,
-    vip,
+    vip (>= 0.4.1),
     workflows
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.3
 Suggests: 
     forcats,
     ggplot2,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# workboots 0.2.1
+
+* Workboots now requires that [`{vip}`](https://koalaverse.github.io/vip/) is at least version 0.4.1 (addresses [`{vip}`'s removal from CRAN](https://github.com/koalaverse/vip/issues/153)).
+
 # workboots 0.2.0
 
 ### Function updates

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,10 +1,8 @@
 ## Release summary
 
-This release moves the package to 0.2.0. In this version I have:
+This release moves the package to 0.2.1. In this version I have:
 
-* Rearranged column order output of `summarise_*` functions from `*_lower`, `*`, `*_upper` to `*`, `*_lower`, `*_upper`
-* Deprecated `conf` parameter in `summarise_*` functions in favor of `interval_width`.
-* Added support for generating confidence intervals from `predict_boots()`. 
+* Updated package dependencies to depend on vip version 0.4.1. vip 0.4.1 fixes issues that caused vip 0.4.0 to be removed from CRAN.  
 
 ## R CMD check results
 There were no ERRORs, WARNINGs, or NOTEs.


### PR DESCRIPTION
Forces vip version 0.4.1 or greater --- addresses [CRAN issues in vip](https://github.com/koalaverse/vip/issues/153)