### PR TITLE
Allow workflows with formulas

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,7 @@ URL: https://github.com/markjrieke/workboots,
 BugReports: https://github.com/markjrieke/workboots/issues
 Imports:
     assertthat,
+    cli,
     dplyr,
     generics,
     lifecycle,
@@ -33,7 +34,7 @@ Imports:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0
 Suggests: 
     forcats,
     ggplot2,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Suggests:
     ggplot2,
     kknn,
     knitr,
+    parsnip,
     readr,
     recipes,
     rmarkdown,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # workboots 0.2.1
 
 * Workboots now requires that [`{vip}`](https://koalaverse.github.io/vip/) is at least version 0.4.1 (addresses [`{vip}`'s removal from CRAN](https://github.com/koalaverse/vip/issues/153)).
+* Workflows with formulas (and not recipes) can be used. 
+* [predict_boots()] now requires a _fitted_ workflow. 
 
 # workboots 0.2.0
 

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -55,23 +55,9 @@ assert_n <- function(n) {
 # Util function for checking training_data and new_data params
 assert_pred_data <- function(workflow, data, type) {
 
-  # get colnames from workflow
-  var_info <- workflow$pre$actions$recipe$recipe$var_info
-
-  if (type == "training") {
-
-    # check that colnames include all predictors and outcomes
-    var_info <- dplyr::filter(var_info, role %in% c("predictor", "outcome"))
-
-  } else { # type == "new"
-
-    # check that colnames include all predictors
-    var_info <- dplyr::filter(var_info, role == "predictor")
-
-  }
+  cols_wf <- column_names(workflow, training = type == "training")
 
   # get colnames for comparison
-  cols_wf <- var_info$variable
   cols_dat <- colnames(data)
 
   # check that all cols in wf appear in data
@@ -84,6 +70,16 @@ assert_pred_data <- function(workflow, data, type) {
   )
 
 }
+
+column_names <- function(x, training = TRUE) {
+  col_names <- .get_input_predictors_workflow(x)
+  if (training) {
+    col_names <- c(col_names, .get_input_outcome_workflow(x))
+  }
+  col_names
+}
+
+
 
 # Util function for checking .data passed to summary functions
 assert_pred_summary <- function(data) {

--- a/R/predict_boots.R
+++ b/R/predict_boots.R
@@ -166,8 +166,7 @@ predict_single_boot <- function(workflow,
   preds <- stats::predict(model, new_data)
 
   # get predicted var name
-  pred_name <- dplyr::filter(workflow$pre$actions$recipe$recipe$var_info, role == "outcome")
-  pred_name <- dplyr::pull(pred_name, variable)
+  pred_name <- .get_input_outcome_workflow(model)
 
   # apply prediction interval using bootstrap 632+ estimate
   # if not, just returns absolute prediction (when summarised, this generates a confidence interval)

--- a/R/standalone-input-names.R
+++ b/R/standalone-input-names.R
@@ -1,0 +1,83 @@
+# ---
+# repo: tidymodels/workflows
+# file: standalone-input-names.R
+# last-updated: 2024-01-291
+# license: https://unlicense.org
+# requires: cli, rlang
+# ---
+
+# This file provides a portable set of helper functions for determining the
+# names of the predictor columns used as inputs into a workflow.
+
+# ## Changelog
+# 2024-01-21
+# * First version
+# 2024-01-29
+# * Changes after PR review
+
+# nocov start
+
+# ------------------------------------------------------------------------------
+# Primary functions
+
+# @param x A _fitted_ workflow or recipe.
+# @param call An environment indicating where the top-level function was invoked
+# to print out better errors.
+# @return A character vector of sorted columns names.
+
+.get_input_predictors_workflow <- function(x, ..., call = rlang::current_env()) {
+  check_workflow_fit(x, call = call)
+  # We can get the columns that are inputs to the recipe but some of these may
+  # not be predictors. We'll interrogate the recipe and pull out the current
+  # predictor names from the original input
+  if ("recipe" %in% names(x$pre$actions)) {
+    mold <- x$pre$mold
+    rec <- mold$blueprint$recipe
+    res <- .get_input_predictors_recipe(rec)
+  } else {
+    res <- blueprint_ptype(x)
+  }
+  sort(unique(res))
+}
+
+.get_input_predictors_recipe <- function(x, ..., call = rlang::current_env()) {
+  check_recipe_fit(x, call = call)
+  var_info <- x$last_term_info
+
+  keep_rows <- var_info$source == "original" & is_predictor_role(var_info)
+  var_info <- var_info[keep_rows,]
+  var_info$variable
+}
+
+.get_input_outcome_workflow <- function(x) {
+  check_workflow_fit(x)
+  names(x$pre$mold$blueprint$ptypes$outcomes)
+}
+
+# ------------------------------------------------------------------------------
+# Helper functions
+
+check_workflow_fit <- function(x, call) {
+  if (!x$trained) {
+    cli::cli_abort("The workflow should be trained.", call = call)
+  }
+  invisible(NULL)
+}
+
+check_recipe_fit <- function(x, call) {
+  is_trained <- vapply(x$steps, function(x) x$trained, logical(1))
+  if (!all(is_trained)) {
+    cli::cli_abort("All recipe steps should be trained.", call = call)
+  }
+  invisible(NULL)
+}
+
+blueprint_ptype <- function(x) {
+  names(x$pre$mold$blueprint$ptypes$predictors)
+}
+
+is_predictor_role <- function(x) {
+  vapply(x$role, function(x) any(x == "predictor"), logical(1))
+}
+
+# nocov end

--- a/R/vi_boots.R
+++ b/R/vi_boots.R
@@ -17,7 +17,7 @@
 #'  Similarly, the number of nested rows may vary by model type as some models
 #'  may not utilize every possible predictor.
 #'
-#' @param workflow An un-fitted workflow object.
+#' @param workflow An fitted workflow object.
 #' @param training_data A tibble or dataframe of data to be resampled and used for training.
 #' @param n An integer for the number of bootstrap resampled models that will be created.
 #' @param verbose A logical. Defaults to `FALSE`. If set to `TRUE`, prints progress

--- a/man/predict_boots.Rd
+++ b/man/predict_boots.Rd
@@ -15,7 +15,7 @@ predict_boots(
 )
 }
 \arguments{
-\item{workflow}{An un-fitted workflow object.}
+\item{workflow}{An fitted workflow object.}
 
 \item{n}{An integer for the number of bootstrap resampled models that will be created.}
 

--- a/man/vi_boots.Rd
+++ b/man/vi_boots.Rd
@@ -7,7 +7,7 @@
 vi_boots(workflow, n = 2000, training_data, verbose = FALSE, ...)
 }
 \arguments{
-\item{workflow}{An un-fitted workflow object.}
+\item{workflow}{An fitted workflow object.}
 
 \item{n}{An integer for the number of bootstrap resampled models that will be created.}
 

--- a/tests/testthat/_snaps/predict-boots.md
+++ b/tests/testthat/_snaps/predict-boots.md
@@ -1,0 +1,20 @@
+# predict_boots() throws an error when training_data/new_data doesn't match expected format
+
+    Code
+      predict_boots(workflow = test_wf_fit, n = 1, training_data = test_train[, 3],
+      new_data = test_test)
+    Condition
+      Error:
+      ! missing cols in training_data:
+      bill_depth_mm, bill_length_mm, flipper_length_mm, island, sex, species, body_mass_g
+
+---
+
+    Code
+      predict_boots(workflow = test_wf_fit, n = 1, training_data = test_train,
+        new_data = test_test[, 3])
+    Condition
+      Error:
+      ! missing cols in new_data:
+      bill_depth_mm, bill_length_mm, flipper_length_mm, island, sex, species
+

--- a/tests/testthat/_snaps/vi-boots.md
+++ b/tests/testthat/_snaps/vi-boots.md
@@ -1,0 +1,43 @@
+# vi_boots() throws an error when not passed a workflow
+
+    Code
+      vi_boots(workflow = test_train, n = 1, training_data = test_train)
+    Condition
+      Error:
+      ! argument `workflow` must be of class "workflow".
+
+# vi_boots() throws an error when workflow is not fit
+
+    Code
+      vi_boots(workflow = test_wf_bad, n = 1, training_data = test_train)
+    Condition
+      Error in `map()`:
+      i In index: 1.
+      Caused by error:
+      ! all tuning parameters must be final before passing workflow to `predict_boots()`.
+
+# vi_boots() throws an error when bad n is specified
+
+    Code
+      vi_boots(workflow = test_wf_fit, n = 0, training_data = test_train)
+    Condition
+      Error:
+      ! argument `n` must be >= 1.
+
+---
+
+    Code
+      vi_boots(workflow = test_wf_fit, n = 1.5, training_data = test_train)
+    Condition
+      Error:
+      ! argmuent `n` must be an integer.
+
+# vi_boots() throws an error when training_data doesn't match expected format
+
+    Code
+      vi_boots(workflow = test_wf_fit, n = 1, training_data = test_train[, 3])
+    Condition
+      Error:
+      ! missing cols in training_data:
+      bill_depth_mm, bill_length_mm, flipper_length_mm, island, sex, species, body_mass_g
+

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -1,0 +1,22 @@
+# ------------------------------------------------------------------------------
+# for 'test-predict-boots.R'
+
+# read in data to use in tests
+# test_wf: wf using xgboost to predict body_mass_g from all predictors in the
+#          palmer penguins dataset. one recipe step - step_dummy(all_nominal())
+# test_train: training df of palmer penguins
+# test_test: testing df of palmer penguins
+test_wf <- readRDS("data/test_wf.rds")
+test_train <- read.csv("data/test_train.csv")
+test_test <- read.csv("data/test_test.csv")
+
+# load bad wf - same as test_wf but has 1 non-final tuning param
+test_wf_bad <- readRDS("data/test_wf_bad.rds")
+
+# ------------------------------------------------------------------------------
+# for 'test-summarise-boots.R'
+
+# read in test data
+test_preds <- readRDS("data/test_preds.rds")
+test_importances <- readRDS("data/test_importances.rds")
+

--- a/tests/testthat/test-summarise-boots.R
+++ b/tests/testthat/test-summarise-boots.R
@@ -1,11 +1,5 @@
-# read in test data
-test_preds <- readRDS("data/test_preds.rds")
-test_importances <- readRDS("data/test_importances.rds")
 
 test_that("summarise_predictions() returns predictions in expected format", {
-
-  # read in data used to make predictions (new_data in predict_boots())
-  test_test <- read.csv("data/test_test.csv")
 
   # generate summary
   x <- summarise_predictions(test_preds)

--- a/tests/testthat/test-summarise-boots.R
+++ b/tests/testthat/test-summarise-boots.R
@@ -33,3 +33,47 @@ test_that("summarise_importances() returns importances in expected format", {
   expect_type(x$.importances[[1]]$model.importance, "double")
 
 })
+
+
+test_that("summarise_predictions() can use formula interface", {
+  skip_if_not_installed("parsnip")
+  suppressPackageStartupMessages(library(workflows))
+  suppressPackageStartupMessages(library(parsnip))
+
+  car_subset <- mtcars[, c("mpg", "disp", "wt")]
+  lm_wflow <- workflow(mpg ~ ., parsnip::linear_reg())
+  lm_fit <- fit(lm_wflow, car_subset)
+
+  new_car <- data.frame(disp = 150.0, wt = 2.5)
+
+  # generate predictions
+  expect_warning(
+    x <-
+      predict_boots(
+        workflow = lm_fit,
+        n = 5,
+        training_data = car_subset,
+        new_data = new_car
+      ),
+
+    "At least 2000 resamples recommended for stable results."
+  )
+
+  # tests
+  # generate summary
+  x <- summarise_predictions(x)
+
+  # tests
+  expect_s3_class(x, c("tbl_df", "tbl", "data.frame"))
+  expect_named(x, c("rowid", ".preds", ".pred", ".pred_lower", ".pred_upper"))
+  expect_type(x$.preds, "list")
+  expect_type(x$.pred_lower, "double")
+  expect_type(x$.pred, "double")
+  expect_type(x$.pred_upper, "double")
+  expect_type(x$.preds[[1]]$model, "character")
+  expect_type(x$.preds[[1]]$model.pred, "double")
+  expect_equal(nrow(x), nrow(new_car))
+
+
+})
+

--- a/tests/testthat/test-vi-boots.R
+++ b/tests/testthat/test-vi-boots.R
@@ -1,18 +1,16 @@
-# read in data to use in tests
-# test_wf: wf using xgboost to predict body_mass_g from all predictors in the
-#          palmer penguins dataset. one recipe step - step_dummy(all_nominal())
-# test_train: training df of palmer penguins
-# test_test: testing df of palmer penguins
-test_wf <- readRDS("data/test_wf.rds")
-test_train <- read.csv("data/test_train.csv")
-
 test_that("vi_boots() returns importances in expected format", {
+
+  skip_if_not_installed("xgboost")
+  suppressPackageStartupMessages(library(workflows))
+  suppressPackageStartupMessages(library(parsnip))
+
+  test_wf_fit <- fit(test_wf, test_train)
 
   # generate predictions
   expect_warning(
     x <-
       vi_boots(
-        workflow = test_wf,
+        workflow = test_wf_fit,
         n = 5,
         training_data = test_train
       ),
@@ -20,7 +18,6 @@ test_that("vi_boots() returns importances in expected format", {
     "At least 2000 resamples recommended for stable results."
 
   )
-
 
   # tests
   expect_s3_class(x, c("tbl_df", "tbl", "data.frame"))
@@ -32,71 +29,74 @@ test_that("vi_boots() returns importances in expected format", {
 
 test_that("vi_boots() throws an error when not passed a workflow", {
 
-  expect_error(
+  expect_snapshot(
     vi_boots(
       workflow = test_train,
       n = 1,
       training_data = test_train
     ),
-
-    "argument `workflow` must be of class \"workflow\"."
+    error = TRUE
   )
 
 })
 
-test_that("vi_boots() throws an error when workflow is not final", {
+test_that("vi_boots() throws an error when workflow is not fit", {
 
-  # load bad wf - same as test_wf but has 1 non-final tuning param
-  test_wf_bad <- readRDS("data/test_wf_bad.rds")
-
-  expect_error(
+  expect_snapshot(
     vi_boots(
       workflow = test_wf_bad,
       n = 1,
       training_data = test_train
     ),
-
-    "all tuning parameters must be final."
+    error = TRUE
   )
 
 })
 
 test_that("vi_boots() throws an error when bad n is specified", {
 
-  expect_error(
+  skip_if_not_installed("xgboost")
+  suppressPackageStartupMessages(library(workflows))
+  suppressPackageStartupMessages(library(parsnip))
+
+  test_wf_fit <- fit(test_wf, test_train)
+
+  expect_snapshot(
     vi_boots(
-      workflow = test_wf,
+      workflow = test_wf_fit,
       n = 0,
       training_data = test_train
     ),
-
-    "argument `n` must be >= 1."
+    error = TRUE
   )
 
-  expect_error(
+  expect_snapshot(
     vi_boots(
-      workflow = test_wf,
+      workflow = test_wf_fit,
       n = 1.5,
       training_data = test_train
     ),
-
-    "argmuent `n` must be an integer."
+    error = TRUE
   )
 
 })
 
 test_that("vi_boots() throws an error when training_data doesn't match expected format", {
 
+  skip_if_not_installed("xgboost")
+  suppressPackageStartupMessages(library(workflows))
+  suppressPackageStartupMessages(library(parsnip))
+
+  test_wf_fit <- fit(test_wf, test_train)
+
   # predictors & outcome missing from training_data
-  expect_error(
+  expect_snapshot(
     vi_boots(
-      workflow = test_wf,
+      workflow = test_wf_fit,
       n = 1,
       training_data = test_train[, 3]
     ),
-
-    paste0("missing cols in training_data:\n",
-           "species, island, bill_length_mm, bill_depth_mm, flipper_length_mm, sex, body_mass_g")
+    error = TRUE
   )
 
 })

--- a/tests/testthat/test-vi-boots.R
+++ b/tests/testthat/test-vi-boots.R
@@ -1,6 +1,7 @@
 test_that("vi_boots() returns importances in expected format", {
 
   skip_if_not_installed("xgboost")
+  skip_if_not_installed("parsnip")
   suppressPackageStartupMessages(library(workflows))
   suppressPackageStartupMessages(library(parsnip))
 
@@ -56,6 +57,7 @@ test_that("vi_boots() throws an error when workflow is not fit", {
 test_that("vi_boots() throws an error when bad n is specified", {
 
   skip_if_not_installed("xgboost")
+  skip_if_not_installed("parsnip")
   suppressPackageStartupMessages(library(workflows))
   suppressPackageStartupMessages(library(parsnip))
 
@@ -84,6 +86,7 @@ test_that("vi_boots() throws an error when bad n is specified", {
 test_that("vi_boots() throws an error when training_data doesn't match expected format", {
 
   skip_if_not_installed("xgboost")
+  skip_if_not_installed("parsnip")
   suppressPackageStartupMessages(library(workflows))
   suppressPackageStartupMessages(library(parsnip))
 

--- a/vignettes/Estimating-Linear-Intervals.Rmd
+++ b/vignettes/Estimating-Linear-Intervals.Rmd
@@ -36,7 +36,7 @@ ames_mod %>%
   ggplot(aes(x = First_Flr_SF, y = Sale_Price)) +
   geom_point(alpha = 0.25) +
   scale_x_log10(labels = scales::comma_format()) +
-  scale_y_log10(labels = scales::label_number(scale_cut = scales::cut_short_scale()))
+  scale_y_log10(labels = scales::label_number())
 ```
 
 We can use a linear model to predict the log transform of `Sale_Price` based on the log transform of `First_Flr_SF`and plot our predictions against a holdout set with a prediction interval. 
@@ -79,7 +79,7 @@ ames_lm_pred_int %>%
                   ymax = upr),
               alpha = 0.25) +
   scale_x_log10(labels = scales::comma_format()) +
-  scale_y_log10(labels = scales::label_number(scale_cut = scales::cut_short_scale()))
+  scale_y_log10(labels = scales::label_number())
 ```
 
 We can use workboots to approximate the linear model's prediction interval by passing a workflow built on a linear model to `predict_boots()`.
@@ -129,7 +129,7 @@ ames_boot_pred_int %>%
   geom_point(aes(y = Sale_Price),
              alpha = 0.25) +
   scale_x_log10(labels = scales::comma_format()) +
-  scale_y_log10(labels = scales::label_number(scale_cut = scales::cut_short_scale())) +
+  scale_y_log10(labels = scales::label_number()) +
   
   # add prediction interval created by lm()
   geom_line(aes(y = fit),
@@ -185,7 +185,7 @@ ames_boot_pred_int %>%
               alpha = 0.25,
               fill = "blue") +
   scale_x_log10(labels = scales::comma_format()) +
-  scale_y_log10(labels = scales::label_number(scale_cut = scales::cut_short_scale()))
+  scale_y_log10(labels = scales::label_number())
 ```
 
 Alternatively, we can estimate the confidence interval around each prediction by passing the argument `"confidence"` to the `interval` parameter of `predict_boots()`. 
@@ -235,7 +235,7 @@ ames_boot_conf_int %>%
   geom_point(aes(y = Sale_Price),
              alpha = 0.25) +
   scale_x_log10(labels = scales::comma_format()) +
-  scale_y_log10(labels = scales::label_number(scale_cut = scales::cut_short_scale())) +
+  scale_y_log10(labels = scales::label_number()) +
   
   # add prediction interval created by lm()
   geom_line(aes(y = fit),

--- a/vignettes/Estimating-Linear-Intervals.Rmd
+++ b/vignettes/Estimating-Linear-Intervals.Rmd
@@ -93,10 +93,12 @@ ames_wf <-
   add_recipe(recipe(Sale_Price ~ First_Flr_SF, data = ames_train)) %>%
   add_model(linear_reg())
 
+ames_fit <- fit(ames_wf, ames_train)
+
 # generate bootstrap predictions on ames test
 set.seed(713)
 ames_boot_pred_int <- 
-  ames_wf %>%
+  ames_fit %>%
   predict_boots(
     n = 2000,
     training_data = ames_train,

--- a/vignettes/Getting-Started-with-workboots.Rmd
+++ b/vignettes/Getting-Started-with-workboots.Rmd
@@ -79,13 +79,13 @@ car_val_rec <-
 
 # fit and predict on our validation set
 set.seed(777)
-car_val_preds <- 
+car_val_fit <- 
   workflow() %>%
   add_recipe(car_val_rec) %>%
   add_model(boost_tree("regression", engine = "xgboost")) %>%
-  fit(car_val_train) %>%
-  predict(car_val_test) %>%
-  bind_cols(car_val_test)
+  fit(car_val_train)
+
+car_val_preds <- augment(car_val_fit, car_val_test)
 
 car_val_preds %>%
   rmse(truth = Price, estimate = .pred)
@@ -182,6 +182,8 @@ car_wf_final <-
   finalize_workflow(car_tune %>% select_best("rmse"))
 
 car_wf_final
+
+car_wf_final_fit <- fit(car_wf_final, car_train)
 ```
 
 ## Predicting price ranges
@@ -193,7 +195,7 @@ library(workboots)
 
 set.seed(444)
 car_preds <-
-  car_wf_final %>%
+  car_wf_final_fit %>%
   predict_boots(
     n = 2000,
     training_data = car_train,

--- a/vignettes/The-Math-Behind-workboots.Rmd
+++ b/vignettes/The-Math-Behind-workboots.Rmd
@@ -180,8 +180,8 @@ tibble(.pred = preds_train_mod) %>%
        subtitle = "Adding a single error estimate produces poor predictions of price",
        x = "Predicted price",
        y = "Actual price") +
-  scale_x_log10(labels = scales::label_dollar(scale_cut = cut_short_scale())) +
-  scale_y_log10(labels = scales::label_dollar(scale_cut = cut_short_scale())) 
+  scale_x_log10(labels = scales::label_dollar()) +
+  scale_y_log10(labels = scales::label_dollar()) 
   
 ```
 
@@ -217,8 +217,8 @@ sacramento_pred_int %>%
   geom_errorbar(alpha = 0.25,
                 color = "midnightblue",
                 width = 0.0125) +
-  scale_x_log10(labels = scales::label_dollar(scale_cut = cut_short_scale())) +
-  scale_y_log10(labels = scales::label_dollar(scale_cut = cut_short_scale())) +
+  scale_x_log10(labels = scales::label_dollar()) +
+  scale_y_log10(labels = scales::label_dollar()) +
   geom_abline(linetype = "dashed",
               size = 1,
               color = "gray") +

--- a/vignettes/The-Math-Behind-workboots.Rmd
+++ b/vignettes/The-Math-Behind-workboots.Rmd
@@ -75,6 +75,7 @@ sacramento_wf <-
   add_recipe(sacramento_recipe) %>%
   add_model(sacramento_spec)
 
+# Fit to the first bootstrap sample 
 set.seed(876)
 sacramento_fit <-
   sacramento_wf %>%
@@ -190,11 +191,14 @@ With workboots, however, we can repeat this process over many bootstrap datasets
 ```{r, class.source = 'fold-show'}
 library(workboots)
 
+# Fit the to entire training set. 
+sacramento_training_fit <- fit(sacramento_wf, sacramento_train) 
+
 # fit and predict price in sacramento_test from 100 models
 # the default number of resamples is 2000 - dropping here to speed up knitting
 set.seed(555)
 sacramento_pred_int <-
-  sacramento_wf %>%
+  sacramento_training_fit %>%
   predict_boots(
     n = 100,
     training_data = sacramento_train,


### PR DESCRIPTION
Closes #56 

The main API change is that a fitted workflow would now be required. That made the changes a little more invasive than I hoped they would be since it affects documentation and testing. 

I could make the testing code a little more simple with some changes that would avoid a bunch of `expect_type()` and `expect_s3_class()` calls. Now sure how much more you would like me to make more changes.

On the bright side: 

``` r
library(tidymodels)
library(workboots)
```

``` r

car_subset <- mtcars[, c("mpg", "disp", "wt")]
lm_wflow <- workflow(mpg ~ ., parsnip::linear_reg())
lm_fit <- fit(lm_wflow, car_subset)
new_car <- data.frame(disp = 150.0, wt = 2.5)
```

``` r

set.seed(1)
new_car_pred <-
  predict_boots(
    workflow = lm_fit,
    n = 2000,
    training_data = car_subset,
    new_data = new_car
  ) %>% 
  summarise_predictions()

new_car_pred
#> # A tibble: 1 × 5
#>   rowid .preds               .pred .pred_lower .pred_upper
#>   <int> <list>               <dbl>       <dbl>       <dbl>
#> 1     1 <tibble [2,000 × 2]>  23.9        17.7        29.8
```

<sup>Created on 2024-01-29 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>